### PR TITLE
feat: add local digest process-driver samples

### DIFF
--- a/configs/agents/local_pr_patch_digest.yaml
+++ b/configs/agents/local_pr_patch_digest.yaml
@@ -1,0 +1,40 @@
+{
+  "id": "local_pr_patch_digest",
+  "kind": "process",
+  "entrypoint": "drivers/local_pr_patch_digest_adapter.sh",
+  "version": "0.1",
+  "capabilities": [
+    "read_repo",
+    "write_repo",
+    "run_shell",
+    "produce_patchable_changes"
+  ],
+  "default_mode": "apply_in_workspace",
+  "policy_defaults": {
+    "timeout_sec": 900,
+    "max_steps": 1,
+    "network": "disabled",
+    "network_allowlist": [],
+    "tool_allowlist": [
+      "read",
+      "write",
+      "bash"
+    ],
+    "allowed_paths": [
+      "src/**",
+      "tests/**",
+      "docs/**"
+    ],
+    "forbidden_paths": [
+      ".git/**",
+      "logs/**",
+      ".masfactory_runtime/**",
+      "memory/**"
+    ],
+    "max_changed_files": 10,
+    "max_patch_lines": 400,
+    "allow_binary_changes": false,
+    "cleanup_on_success": true,
+    "retain_workspace_on_failure": true
+  }
+}

--- a/configs/agents/local_repo_digest.yaml
+++ b/configs/agents/local_repo_digest.yaml
@@ -1,0 +1,40 @@
+{
+  "id": "local_repo_digest",
+  "kind": "process",
+  "entrypoint": "drivers/local_repo_digest_adapter.sh",
+  "version": "0.1",
+  "capabilities": [
+    "read_repo",
+    "write_repo",
+    "run_shell",
+    "produce_patchable_changes"
+  ],
+  "default_mode": "apply_in_workspace",
+  "policy_defaults": {
+    "timeout_sec": 900,
+    "max_steps": 1,
+    "network": "disabled",
+    "network_allowlist": [],
+    "tool_allowlist": [
+      "read",
+      "write",
+      "bash"
+    ],
+    "allowed_paths": [
+      "src/**",
+      "tests/**",
+      "docs/**"
+    ],
+    "forbidden_paths": [
+      ".git/**",
+      "logs/**",
+      ".masfactory_runtime/**",
+      "memory/**"
+    ],
+    "max_changed_files": 10,
+    "max_patch_lines": 400,
+    "allow_binary_changes": false,
+    "cleanup_on_success": true,
+    "retain_workspace_on_failure": true
+  }
+}

--- a/docs/agent-snippets/local_pr_patch_digest.md
+++ b/docs/agent-snippets/local_pr_patch_digest.md
@@ -1,0 +1,11 @@
+Use this driver via:
+
+```bash
+make agent-run AEP_AGENT=local_pr_patch_digest AEP_TASK="Describe the task here."
+```
+
+Generated files:
+
+- `configs/agents/local_pr_patch_digest.yaml`
+- `drivers/local_pr_patch_digest_adapter.sh`
+- `tests/test_local_pr_patch_digest_adapter.py`

--- a/docs/agent-snippets/local_repo_digest.md
+++ b/docs/agent-snippets/local_repo_digest.md
@@ -1,0 +1,11 @@
+Use this driver via:
+
+```bash
+make agent-run AEP_AGENT=local_repo_digest AEP_TASK="Describe the task here."
+```
+
+Generated files:
+
+- `configs/agents/local_repo_digest.yaml`
+- `drivers/local_repo_digest_adapter.sh`
+- `tests/test_local_repo_digest_adapter.py`

--- a/drivers/local_pr_patch_digest_adapter.sh
+++ b/drivers/local_pr_patch_digest_adapter.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local key="$1"
+  if [[ -z "${!key:-}" ]]; then
+    echo "[aep][local_pr_patch_digest] missing env: ${key}" >&2
+    exit 40
+  fi
+}
+
+require_env "AEP_WORKSPACE"
+require_env "AEP_JOB_SPEC"
+require_env "AEP_RESULT_PATH"
+require_env "AEP_ARTIFACT_DIR"
+
+PY_BIN="${PYTHON_BIN:-python3}"
+
+"${PY_BIN}" - "${AEP_WORKSPACE}" "${AEP_JOB_SPEC}" "${AEP_RESULT_PATH}" "${AEP_ARTIFACT_DIR}" <<'PY'
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+import sys
+
+
+def run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+    )
+    if check and completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip() or f"git {' '.join(args)} failed")
+    return completed
+
+
+workspace = Path(sys.argv[1])
+job_path = Path(sys.argv[2])
+result_path = Path(sys.argv[3])
+artifact_dir = Path(sys.argv[4])
+payload = json.loads(job_path.read_text(encoding="utf-8"))
+started = time.perf_counter()
+
+try:
+    inside = run_git(["rev-parse", "--is-inside-work-tree"]).stdout.strip()
+    if inside != "true":
+        raise RuntimeError("repository root is not a git work tree")
+
+    branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    has_origin_main = run_git(
+        ["show-ref", "--verify", "--quiet", "refs/remotes/origin/main"],
+        check=False,
+    ).returncode == 0
+
+    if has_origin_main:
+        base_label = "origin/main"
+        base_ref = run_git(["merge-base", "HEAD", "origin/main"]).stdout.strip()
+    else:
+        head_parent = run_git(["rev-parse", "HEAD~1"], check=False)
+        if head_parent.returncode != 0:
+            raise RuntimeError("local_pr_patch_digest requires either origin/main or at least two commits")
+        base_label = "HEAD~1"
+        base_ref = head_parent.stdout.strip()
+
+    name_status = run_git(["diff", "--name-status", f"{base_ref}..HEAD"]).stdout.splitlines()
+    numstat_lines = run_git(["diff", "--numstat", f"{base_ref}..HEAD"]).stdout.splitlines()
+    shortstat = run_git(["diff", "--shortstat", f"{base_ref}..HEAD"]).stdout.strip() or "no committed diff"
+    dirty_status = run_git(["status", "--short"]).stdout.splitlines()
+
+    insertions = 0
+    deletions = 0
+    changed_files: list[str] = []
+    for line in numstat_lines:
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        added, removed, path = parts
+        if added.isdigit():
+            insertions += int(added)
+        if removed.isdigit():
+            deletions += int(removed)
+        changed_files.append(path)
+
+    digest_rel = Path("docs/local_pr_patch_digest.md")
+    digest_path = workspace / digest_rel
+    digest_path.parent.mkdir(parents=True, exist_ok=True)
+    digest_lines = [
+        "# Local PR Patch Digest",
+        "",
+        f"- task: {payload.get('task', '').strip() or 'unspecified'}",
+        f"- branch: {branch}",
+        f"- base: {base_label}",
+        f"- changed files: {len(changed_files)}",
+        f"- insertions: {insertions}",
+        f"- deletions: {deletions}",
+        f"- shortstat: {shortstat}",
+        "",
+        "## Changed Files",
+    ]
+    if name_status:
+        digest_lines.extend(f"- `{line}`" for line in name_status[:20])
+    else:
+        digest_lines.append("- none")
+    digest_lines.extend(["", "## Dirty Working Tree"])
+    if dirty_status:
+        digest_lines.extend(f"- `{line}`" for line in dirty_status[:20])
+    else:
+        digest_lines.append("- clean")
+    digest_path.write_text("\n".join(digest_lines) + "\n", encoding="utf-8")
+    artifact_report_path = artifact_dir / "local_pr_patch_digest.md"
+    shutil.copyfile(digest_path, artifact_report_path)
+
+    stats_path = artifact_dir / "local_pr_patch_digest_stats.json"
+    stats_payload = {
+        "branch": branch,
+        "base_label": base_label,
+        "base_ref": base_ref,
+        "changed_files": changed_files,
+        "insertions": insertions,
+        "deletions": deletions,
+        "dirty_status": dirty_status,
+    }
+    stats_path.write_text(json.dumps(stats_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    result = {
+        "protocol_version": "aep/v0",
+        "run_id": payload.get("run_id", "unknown-run"),
+        "agent_id": payload.get("agent_id", "local_pr_patch_digest"),
+        "attempt": 1,
+        "status": "succeeded",
+        "summary": f"Generated patch digest at {digest_rel.as_posix()} using base {base_label}",
+        "changed_paths": [digest_rel.as_posix()],
+        "output_artifacts": [
+            {
+                "name": "local_pr_patch_digest_report",
+                "kind": "report",
+                "uri": str(artifact_report_path),
+                "sha256": None,
+            },
+            {
+                "name": "local_pr_patch_digest_stats",
+                "kind": "report",
+                "uri": str(stats_path),
+                "sha256": None,
+            }
+        ],
+        "metrics": {
+            "duration_ms": duration_ms,
+            "steps": 1,
+            "commands": 4,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+        },
+        "recommended_action": "promote",
+        "error": None,
+    }
+except Exception as exc:
+    result = {
+        "protocol_version": "aep/v0",
+        "run_id": payload.get("run_id", "unknown-run"),
+        "agent_id": payload.get("agent_id", "local_pr_patch_digest"),
+        "attempt": 1,
+        "status": "contract_error",
+        "summary": "local_pr_patch_digest could not determine a local diff source",
+        "changed_paths": [],
+        "output_artifacts": [],
+        "metrics": {
+            "duration_ms": int((time.perf_counter() - started) * 1000),
+            "steps": 0,
+            "commands": 0,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+        },
+        "recommended_action": "reject",
+        "error": str(exc),
+    }
+
+result_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+PY
+
+if [[ "$?" -eq 0 ]]; then
+  exit 0
+fi
+exit 40

--- a/drivers/local_repo_digest_adapter.sh
+++ b/drivers/local_repo_digest_adapter.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local key="$1"
+  if [[ -z "${!key:-}" ]]; then
+    echo "[aep][local_repo_digest] missing env: ${key}" >&2
+    exit 40
+  fi
+}
+
+require_env "AEP_WORKSPACE"
+require_env "AEP_JOB_SPEC"
+require_env "AEP_RESULT_PATH"
+require_env "AEP_ARTIFACT_DIR"
+
+PY_BIN="${PYTHON_BIN:-python3}"
+
+"${PY_BIN}" - "${AEP_WORKSPACE}" "${AEP_JOB_SPEC}" "${AEP_RESULT_PATH}" "${AEP_ARTIFACT_DIR}" <<'PY'
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from collections import Counter
+from pathlib import Path
+
+
+def is_ignored(path: Path) -> bool:
+    parts = set(path.parts)
+    return any(
+        name in parts
+        for name in {".git", ".venv", "node_modules", ".pytest_cache", ".ruff_cache", ".masfactory_runtime"}
+    )
+
+
+def classify(path: Path) -> str:
+    if path.suffix:
+        return path.suffix.lower()
+    return "<no_ext>"
+
+
+workspace = Path(__import__("sys").argv[1])
+job_path = Path(__import__("sys").argv[2])
+result_path = Path(__import__("sys").argv[3])
+artifact_dir = Path(__import__("sys").argv[4])
+payload = json.loads(job_path.read_text(encoding="utf-8"))
+
+started = time.perf_counter()
+files = [
+    path.relative_to(workspace)
+    for path in workspace.rglob("*")
+    if path.is_file() and not is_ignored(path.relative_to(workspace))
+]
+file_types = Counter(classify(path) for path in files)
+top_dirs = Counter(path.parts[0] if len(path.parts) > 1 else "<root>" for path in files)
+notable = [
+    candidate
+    for candidate in (
+        Path("README.md"),
+        Path("Makefile"),
+        Path("pyproject.toml"),
+        Path("configs/agents"),
+        Path("drivers"),
+        Path("tests"),
+    )
+    if (workspace / candidate).exists()
+]
+
+digest_rel = Path("docs/local_repo_digest.md")
+digest_path = workspace / digest_rel
+digest_path.parent.mkdir(parents=True, exist_ok=True)
+
+digest_lines = [
+    "# Local Repository Digest",
+    "",
+    f"- task: {payload.get('task', '').strip() or 'unspecified'}",
+    f"- total files: {len(files)}",
+    f"- top-level areas: {', '.join(f'{name} ({count})' for name, count in top_dirs.most_common(6)) or 'none'}",
+    "",
+    "## Notable Entrypoints",
+]
+if notable:
+    digest_lines.extend(f"- `{path.as_posix()}`" for path in notable)
+else:
+    digest_lines.append("- none")
+
+digest_lines.extend(
+    [
+        "",
+        "## File Type Breakdown",
+    ]
+)
+if file_types:
+    digest_lines.extend(
+        f"- `{suffix}`: {count}" for suffix, count in file_types.most_common(10)
+    )
+else:
+    digest_lines.append("- none")
+
+digest_lines.extend(
+    [
+        "",
+        "## Sample Paths",
+    ]
+)
+if files:
+    digest_lines.extend(f"- `{path.as_posix()}`" for path in files[:12])
+else:
+    digest_lines.append("- none")
+
+digest_path.write_text("\n".join(digest_lines) + "\n", encoding="utf-8")
+artifact_report_path = artifact_dir / "local_repo_digest.md"
+shutil.copyfile(digest_path, artifact_report_path)
+
+stats_path = artifact_dir / "local_repo_digest_stats.json"
+stats_payload = {
+    "total_files": len(files),
+    "file_types": file_types.most_common(10),
+    "top_dirs": top_dirs.most_common(10),
+    "notable": [path.as_posix() for path in notable],
+}
+stats_path.write_text(json.dumps(stats_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+duration_ms = int((time.perf_counter() - started) * 1000)
+result = {
+    "protocol_version": "aep/v0",
+    "run_id": payload.get("run_id", "unknown-run"),
+    "agent_id": payload.get("agent_id", "local_repo_digest"),
+    "attempt": 1,
+    "status": "succeeded",
+    "summary": f"Generated repository digest at {digest_rel.as_posix()}",
+    "changed_paths": [digest_rel.as_posix()],
+    "output_artifacts": [
+        {
+            "name": "local_repo_digest_report",
+            "kind": "report",
+            "uri": str(artifact_report_path),
+            "sha256": None,
+        },
+        {
+            "name": "local_repo_digest_stats",
+            "kind": "report",
+            "uri": str(stats_path),
+            "sha256": None,
+        }
+    ],
+    "metrics": {
+        "duration_ms": duration_ms,
+        "steps": 1,
+        "commands": 0,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+    },
+    "recommended_action": "promote",
+    "error": None,
+}
+result_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+PY
+
+exit 0

--- a/tests/test_local_pr_patch_digest_adapter.py
+++ b/tests/test_local_pr_patch_digest_adapter.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+from autoresearch.agent_protocol.models import ExecutionPolicy, JobSpec
+from autoresearch.executions.runner import AgentExecutionRunner
+
+
+def _copy_bundle(repo_root: Path, agent_id: str) -> None:
+    source_root = Path(__file__).resolve().parents[1]
+    manifest = source_root / "configs" / "agents" / f"{agent_id}.yaml"
+    adapter = source_root / "drivers" / f"{agent_id}_adapter.sh"
+    target_manifest = repo_root / "configs" / "agents" / f"{agent_id}.yaml"
+    target_adapter = repo_root / "drivers" / f"{agent_id}_adapter.sh"
+    target_manifest.parent.mkdir(parents=True, exist_ok=True)
+    target_adapter.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(manifest, target_manifest)
+    shutil.copy2(adapter, target_adapter)
+    target_adapter.chmod(0o755)
+
+
+def _run_git(repo_root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo_root, check=True, text=True, capture_output=True)
+
+
+def test_local_pr_patch_digest_summarizes_current_branch_delta(tmp_path: Path, monkeypatch) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _run_git(repo_root, "init", "-b", "main")
+    _run_git(repo_root, "config", "user.name", "Test User")
+    _run_git(repo_root, "config", "user.email", "test@example.com")
+
+    (repo_root / "README.md").write_text("# Demo Repo\n", encoding="utf-8")
+    _run_git(repo_root, "add", "README.md")
+    _run_git(repo_root, "commit", "-m", "base")
+
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "app.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+    _run_git(repo_root, "add", "src/app.py")
+    _run_git(repo_root, "commit", "-m", "add app")
+
+    _copy_bundle(repo_root, "local_pr_patch_digest")
+
+    runner = AgentExecutionRunner(
+        repo_root=repo_root,
+        runtime_root=tmp_path / "runtime",
+        manifests_dir=repo_root / "configs" / "agents",
+    )
+
+    monkeypatch.setenv("PYTHON_BIN", __import__("sys").executable)
+
+    summary = runner.run_job(
+        JobSpec(
+            run_id="run-local-pr-patch-digest",
+            agent_id="local_pr_patch_digest",
+            task="Summarize the current local patch.",
+            policy=ExecutionPolicy(
+                allowed_paths=["docs/local_pr_patch_digest.md"],
+                forbidden_paths=[".git/**", "logs/**", ".masfactory_runtime/**", "memory/**"],
+                cleanup_on_success=False,
+            ),
+        )
+    )
+
+    assert summary.final_status == "ready_for_promotion"
+    assert summary.driver_result.status == "succeeded"
+    assert summary.driver_result.changed_paths == ["docs/local_pr_patch_digest.md"]
+
+    report = next(
+        item
+        for item in summary.driver_result.output_artifacts
+        if item.name == "local_pr_patch_digest_report"
+    )
+    content = Path(report.uri).read_text(encoding="utf-8")
+    assert "# Local PR Patch Digest" in content
+    assert "HEAD~1" in content
+    assert "src/app.py" in content
+
+    stats = next(
+        item
+        for item in summary.driver_result.output_artifacts
+        if item.name == "local_pr_patch_digest_stats"
+    )
+    payload = json.loads(Path(stats.uri).read_text(encoding="utf-8"))
+    assert payload["base_label"] == "HEAD~1"
+    assert "src/app.py" in payload["changed_files"]

--- a/tests/test_local_repo_digest_adapter.py
+++ b/tests/test_local_repo_digest_adapter.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+
+from autoresearch.agent_protocol.models import ExecutionPolicy, JobSpec
+from autoresearch.executions.runner import AgentExecutionRunner
+
+
+def _copy_bundle(repo_root: Path, agent_id: str) -> None:
+    source_root = Path(__file__).resolve().parents[1]
+    manifest = source_root / "configs" / "agents" / f"{agent_id}.yaml"
+    adapter = source_root / "drivers" / f"{agent_id}_adapter.sh"
+    target_manifest = repo_root / "configs" / "agents" / f"{agent_id}.yaml"
+    target_adapter = repo_root / "drivers" / f"{agent_id}_adapter.sh"
+    target_manifest.parent.mkdir(parents=True, exist_ok=True)
+    target_adapter.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(manifest, target_manifest)
+    shutil.copy2(adapter, target_adapter)
+    target_adapter.chmod(0o755)
+
+
+def test_local_repo_digest_generates_summary_doc(tmp_path: Path, monkeypatch) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "README.md").write_text("# Demo Repo\n", encoding="utf-8")
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    (repo_root / "tests").mkdir()
+    (repo_root / "tests" / "test_app.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    _copy_bundle(repo_root, "local_repo_digest")
+
+    runner = AgentExecutionRunner(
+        repo_root=repo_root,
+        runtime_root=tmp_path / "runtime",
+        manifests_dir=repo_root / "configs" / "agents",
+    )
+
+    monkeypatch.setenv("PYTHON_BIN", __import__("sys").executable)
+
+    summary = runner.run_job(
+        JobSpec(
+            run_id="run-local-repo-digest",
+            agent_id="local_repo_digest",
+            task="Summarize the local repository.",
+            policy=ExecutionPolicy(
+                allowed_paths=["docs/local_repo_digest.md"],
+                forbidden_paths=[".git/**", "logs/**", ".masfactory_runtime/**", "memory/**"],
+                cleanup_on_success=False,
+            ),
+        )
+    )
+
+    assert summary.final_status == "ready_for_promotion"
+    assert summary.driver_result.status == "succeeded"
+    assert summary.driver_result.changed_paths == ["docs/local_repo_digest.md"]
+
+    digest_path = Path(summary.promotion_patch_uri or "").parent / "workspace_unused"
+    _ = digest_path
+    patch_text = Path(summary.promotion_patch_uri or "").read_text(encoding="utf-8")
+    assert "docs/local_repo_digest.md" in patch_text
+
+    report = next(
+        item for item in summary.driver_result.output_artifacts if item.name == "local_repo_digest_report"
+    )
+    content = Path(report.uri).read_text(encoding="utf-8")
+    assert "# Local Repository Digest" in content
+    assert "`README.md`" in content
+
+    stats = next(
+        item for item in summary.driver_result.output_artifacts if item.name == "local_repo_digest_stats"
+    )
+    payload = json.loads(Path(stats.uri).read_text(encoding="utf-8"))
+    assert payload["total_files"] >= 3


### PR DESCRIPTION
## Summary

This PR adds two local, controlled sample process drivers built with the new `agent-scaffold` path:

- `local_repo_digest`
- `local_pr_patch_digest`

The goal is to prove that the one-click process-driver path is repeatable beyond Codex itself.

## What changed

- added `configs/agents/local_repo_digest.yaml`
- added `configs/agents/local_pr_patch_digest.yaml`
- added runnable adapters:
  - `drivers/local_repo_digest_adapter.sh`
  - `drivers/local_pr_patch_digest_adapter.sh`
- added scaffold snippets under `docs/agent-snippets/`
- added adapter tests for both agents

## Behavior

### `local_repo_digest`

- reads the isolated workspace snapshot
- generates `docs/local_repo_digest.md`
- emits a structured stats artifact
- stays fully local and deterministic

### `local_pr_patch_digest`

- reads local repository git diff context from the adapter host repo root
- writes the digest only into the isolated workspace
- generates `docs/local_pr_patch_digest.md`
- emits a structured stats artifact

This keeps the write path inside the AEP workspace while still allowing the sample agent to summarize local patch state.

## Validation

Tests:

- `PYTHONPATH=src .venv/bin/pytest -q tests/test_local_repo_digest_adapter.py tests/test_local_pr_patch_digest_adapter.py tests/test_new_process_driver.py`
- Result: `3 passed, 1 warning`

Real entrypoint smokes:

- `make agent-run AEP_AGENT=local_repo_digest AEP_TASK="Summarize the local repository."`
- `make agent-run AEP_AGENT=local_pr_patch_digest AEP_TASK="Summarize the current local patch."`

Both succeeded with:

- `final_status = ready_for_promotion`
- `driver_result.status = succeeded`
- `promotion.patch` generated

## Why this PR exists

This is the first proof that `agent-scaffold` is not just generating placeholders.
It now produces sample agents that can be scaffolded, implemented, tested, and run through the normal AEP path as small local process adapters.
